### PR TITLE
fix: don't allow mutating original config object by the caller

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -1,3 +1,4 @@
+const clonedeep = require('clone-deep')
 const deepmerge = require('deepmerge')
 const request = require('request-promise-native')
 const getPort = require('get-port')
@@ -15,8 +16,8 @@ const loadConfig = (dir, fixture = null, override = {}, { merge = false } = {}) 
     return deepmerge.all([config, override])
   } else {
     return {
-      ...config,
-      ...override
+      ...clonedeep(config),
+      ...clonedeep(override)
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test": "yarn lint && jest"
   },
   "dependencies": {
+    "clone-deep": "^4.0.1",
     "deepmerge": "^4.1.1",
     "get-port": "^5.0.0",
     "request": "^2.88.0",

--- a/test/setup.test.js
+++ b/test/setup.test.js
@@ -37,4 +37,20 @@ describe('loadConfig', () => {
     const config = loadConfig(__dirname, 'setup', override, { merge: true })
     expect(config.env).toEqual({ ENV1: 'true', ENV2: 'true' })
   })
+
+  test('returns a copy of loaded config when not merging', () => {
+    let config = loadConfig(__dirname, 'setup')
+    config.render.injectScripts = true
+
+    config = loadConfig(__dirname, 'setup')
+    expect(config.render.injectScripts).toEqual(undefined)
+  })
+
+  test('returns a copy of loaded config when merging', () => {
+    const override = { render: { injectScripts: true } }
+    let config = loadConfig(__dirname, 'setup', override, { merge: true })
+
+    config = loadConfig(__dirname, 'setup')
+    expect(config.render.injectScripts).toEqual(undefined)
+  })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2616,6 +2616,15 @@ cliui@^5.0.0:
     strip-ansi "^5.2.0"
     wrap-ansi "^5.1.0"
 
+clone-deep@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/clone-deep/-/clone-deep-4.0.1.tgz#c19fd9bdbbf85942b4fd979c84dcf7d5f07c2387"
+  integrity sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==
+  dependencies:
+    is-plain-object "^2.0.4"
+    kind-of "^6.0.2"
+    shallow-clone "^3.0.0"
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -8935,6 +8944,13 @@ sha.js@^2.4.0, sha.js@^2.4.8:
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
+
+shallow-clone@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/shallow-clone/-/shallow-clone-3.0.1.tgz#8f2981ad92531f55035b01fb230769a40e02efa3"
+  integrity sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==
+  dependencies:
+    kind-of "^6.0.2"
 
 shebang-command@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
`loadConfig` with `merge=false` was using spread operator to
clone  properties from fixture's configuration. Since that is
a shallow copy, child objects were returned by reference and
allowed caller to mutate those objects, affecting further
uses of `loadConfig`. Ensure that is not possible by returning
a copy of loaded config.

This was a problem when one test loaded config and passed it
to Nuxt Builder. Nuxt builder then appended generated plugins
to plugins object and those plugins were then used by subsequent
tests, even if it intended to build new, clean fixture.