### PR TITLE
Inject port to nuxt Builder

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -2,9 +2,10 @@ const build = require('./build')
 const { generatePort } = require('./generate-port')
 
 module.exports = async (config, { port = null, waitFor = 0, beforeNuxtReady = null } = {}) => {
-  const { nuxt, builder } = await build(config, { waitFor, beforeNuxtReady })
+  const _port = await generatePort(config.server && config.server.port ? config.server.port : port)
+  const { nuxt, builder } = await build(Object.assign(config, { server: { port: _port } }), { waitFor, beforeNuxtReady })
 
-  await nuxt.listen(await generatePort(port))
+  await nuxt.listen(_port)
 
   return {
     nuxt,


### PR DESCRIPTION
Some modules may use the listening port from `this.options.server.port` to work. 
As my [library](https://github.com/gaetansenn/xhr-cache/blob/master/lib/module.js#L178)  use this option to work we should inject the defined port to the nuxt config.

In my PR I keep the port argument from setup but I think we should remove it and use the one from nuxt config argument `server.port`.

If you agree to remove it from setup argument I can update the PR and the tests to match with this change.

Regards,

Gaetan SENN