### PR TITLE
fix(generate): start nuxt server before generate

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -9,5 +9,7 @@ export async function generate () {
   const builder = new Builder(nuxt)
   const generator = new Generator(nuxt, builder)
 
-  await generator.generate(options.generate)
+  await nuxt.server.listen(0)
+  await generator.generate(options.generate);
+  await nuxt.close()
 }


### PR DESCRIPTION
There is also another way to start a server, by moving
```js
    if (ctx.options.server) {
      await listen()
    }
```
before
```js
   if (ctx.options.generate) {
      await generate()
    }
```
in the [setup.ts](https://github.com/nuxt-community/module-test-utils/blob/master/src/setup.ts), but it has two downsides:
1. It needs to set `server: true` by user.
2. It does not work without `setupTest` functions